### PR TITLE
fix: remove redundant search button from the recommendations page.

### DIFF
--- a/src/harmoniq/web/templates/recommendations.html
+++ b/src/harmoniq/web/templates/recommendations.html
@@ -140,15 +140,11 @@
 <div class="empty-state" id="emptyState" style="display: none;">
     <i class="fas fa-star"></i>
     <h3>No Recommendations Yet</h3>
-    <p>Click "Discover New Albums" to find music recommendations based on your Last.fm listening history.</p>
-    <button class="btn btn-primary" onclick="triggerDiscovery()">
-        <i class="fas fa-search"></i>
-        Start Discovery
-    </button>
+    <p>Click "Discover New Albums" in the header to find music recommendations based on your Last.fm listening history.</p>
 </div>
 
 <!-- Album Preview Modal -->
-<div class="modal" id="albumPreviewModal">
+<div class="modal" id="albumPreviewModal" style="display: none;">
     <div class="modal-content album-preview-modal">
         <div class="modal-header">
             <h3 id="previewAlbumTitle">Album Preview</h3>


### PR DESCRIPTION
Set album preview modal to none initially.